### PR TITLE
blocks: add block-height route

### DIFF
--- a/app/controllers/blocks_controller.rb
+++ b/app/controllers/blocks_controller.rb
@@ -2,15 +2,26 @@ class BlocksController < ApplicationController
   helper_method :total_out, :confirmations, :max_blocks
   helper_method :get_input_address, :get_announcements, :block_missing
 
-  # GET /blocks
+  # GET /block
   def index
     @blocks = Block.order(:height).reverse.limit(15)
     get_announcements
   end
 
-  # GET /blocks/{hash}
+  # GET /block/{hash}
   def show
     @block = Block.find(:blockHash => params[:id])
+  end
+
+
+  # GET /block-height/{height}
+  def show_height
+    if params[:id].strip.length <= 7
+      @block = Block.find(:height=>params[:id].strip)
+      render "show"
+    else
+      redirect_to("/block/" << params[:id])
+    end
   end
 
   # helpers

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   get 'block' => redirect('/')
   get 'block/:id' => 'blocks#show'
   get 'blocks/:id' => redirect{|params, request| "/block/#{params[:id]}"}
+  get 'block-height/:id' => 'blocks#show_height'
   get 'tx/:txid' => 'transactions#show'
   get 'search/index' => 'searches#index', as: 'search'
   get 'richlist' => 'rich_lists#index', as: 'richlist'


### PR DESCRIPTION
Satisfies #9.

This PR doesn't change the block look up from hash to height, it adds a separate route, called block-height, that will find blocks by height. If a hash is pasted in place of the height, the site will attempt to change the routing from block-height to the normal block route.
